### PR TITLE
Add paypal_commerce to disable-paypal-on-multi-item-checkout

### DIFF
--- a/_checkout/disable-paypal-on-multi-item-checkout.html
+++ b/_checkout/disable-paypal-on-multi-item-checkout.html
@@ -9,23 +9,25 @@ collection: checkout
 /*
  * Plugin Name: Easy Digital Downloads - Disable PayPal for Multi-Item Checkout
  * Description: Disables the PayPal gateway when the cart contains multiple items. PayPal disabled the ability to purchase multiple subscriptions in a single purchase.
- * Author: Sandhills Development
+ * Author: Easy Digital Downloads
  * Author URI: https://easydigitaldownloads.com/
  * Version: 1.0
  */
 
 function pw_edd_disable_paypal_on_multi_item_checkout( $gateways ) {
-	
-	if( edd_is_checkout() && count( edd_get_cart_contents() ) > 1 ) {
 
-		if( ! empty( $gateways['paypal'] ) ) {
+	if ( edd_is_checkout() && count( edd_get_cart_contents() ) > 1 ) {
+		if ( ! empty( $gateways['paypal'] ) ) {
 			unset( $gateways['paypal'] );
 		}
-		if( ! empty( $gateways['paypalexpress'] ) ) {
+		if ( ! empty( $gateways['paypalexpress'] ) ) {
 			unset( $gateways['paypalexpress'] );
 		}
-		if( ! empty( $gateways['paypalpro'] ) ) {
+		if ( ! empty( $gateways['paypalpro'] ) ) {
 			unset( $gateways['paypalpro'] );
+		}
+		if ( ! empty( $gateways['paypal_commerce'] ) ) {
+			unset( $gateways['paypal_commerce'] );
 		}
 
 	}


### PR DESCRIPTION
Fixes #161

Proposed changes:
1. Adds `paypal_commerce` to the function to disable PayPal gateways.
2. Updates the author to Easy Digital Downloads.